### PR TITLE
Document telemetry sources and optimize baro altitude

### DIFF
--- a/doc/configuration.ini
+++ b/doc/configuration.ini
@@ -73,21 +73,46 @@ UART1_BAUDRATE=420000
 # The core data (accel_x, accel_y, accel_z, piezo_mask) is always logged.
 # This list defines which ADDITIONAL fields from app_state will be logged.
 #
-# --- Available GPS Fields ---
-# plane_longitude, plane_latitude, plane_altitude, plane_baro_altitude, plane_fused_altitude,
-# plane_speed, plane_distance, plane_star, plane_fix, plane_heading, plane_vspeed,
-# plane_home_dist, plane_home_dir, plane_gps_hdop, plane_gps_vdop, plane_gps_pdop,
-# plane_gps_fix_mode, plane_gps_sats_in_view, plane_gps_geo_sep, plane_gps_mag_variation,
-# plane_gps_time_hours, plane_gps_time_minutes, plane_gps_time_seconds,
-# plane_gps_date_day, plane_gps_date_month, plane_gps_date_year
+# --- Available Telemetry Fields by Protocol ---
+# The number in parentheses is the size of the field in bytes.
 #
-# --- Available System & RC Fields ---
-# plane_pitch, plane_roll, plane_vbat, plane_battery, plane_rssi, plane_flight_mode, plane_armed,
-# plane_uplink_rssi, plane_uplink_lq, plane_uplink_snr,
-# plane_downlink_rssi, plane_downlink_lq, plane_downlink_snr,
-# plane_rc_channels (Note: this will log all 18 channels, adding 36 bytes to the record)
+# [ CRSF Protocol ]
+# plane_longitude(4), plane_latitude(4), plane_altitude(4), plane_baro_altitude(2),
+# plane_fused_altitude(4), plane_pitch(2), plane_roll(2), plane_heading(2),
+# plane_vbat(2), plane_battery(2), plane_vspeed(2), plane_flight_mode(24),
+# plane_star(1), plane_fix(1), plane_rssi(1),
+# plane_uplink_rssi(1), plane_uplink_lq(1), plane_uplink_snr(1),
+# plane_downlink_rssi(1), plane_downlink_lq(1), plane_downlink_snr(1),
+# plane_rf_power_level(1), plane_vtx_band(1), plane_vtx_channel(1), plane_vtx_power(1),
+# plane_esc_rpm(4), plane_esc_voltage(2), plane_esc_current(2), plane_esc_temperature(1)
 #
-# --- Available ESC Fields ---
-# plane_esc_rpm, plane_esc_voltage, plane_esc_current, plane_esc_temperature
+# [ MAVLINK Protocol ]
+# plane_longitude(4), plane_latitude(4), plane_altitude(4), plane_baro_altitude(2),
+# plane_speed(2), plane_heading(2), plane_vspeed(2)
 #
-#LOG_TELEMETRY=plane_speed,plane_fused_altitude,plane_baro_altitude,plane_vspeed
+# [ MSP Protocol ]
+# plane_longitude(4), plane_latitude(4), plane_altitude(4), plane_baro_altitude(2),
+# plane_speed(2), plane_heading(2), plane_star(1), plane_fix(1),
+# plane_roll(2), plane_pitch(2), plane_vspeed(2), plane_vbat(2), plane_battery(2),
+# plane_rssi(1), plane_armed(1), plane_home_dist(2), plane_home_dir(2),
+# plane_esc_current(2), plane_flight_mode(24)
+#
+# [ MSP_V2 Protocol ]
+# plane_longitude(4), plane_latitude(4), plane_altitude(4),
+# plane_speed(2), plane_heading(2), plane_star(1), plane_fix(1),
+# plane_roll(2), plane_pitch(2), plane_vbat(2), plane_battery(2)
+#
+# [ NMEA Protocol ]
+# plane_longitude(4), plane_latitude(4), plane_altitude(4),
+# plane_speed(2), plane_heading(2), plane_star(1), plane_fix(1),
+# plane_gps_fix_mode(1), plane_gps_sats_in_view(1),
+# plane_gps_hdop(2), plane_gps_vdop(2), plane_gps_pdop(2),
+# plane_gps_geo_sep(2), plane_gps_mag_variation(2),
+# plane_gps_time_hours(1), plane_gps_time_minutes(1), plane_gps_time_seconds(1),
+# plane_gps_date_day(1), plane_gps_date_month(1), plane_gps_date_year(1)
+#
+# [ UBLOX Protocol ]
+# plane_longitude(4), plane_latitude(4), plane_altitude(4),
+# plane_speed(2), plane_heading(2)
+#
+LOG_TELEMETRY=plane_speed,plane_fused_altitude,plane_baro_altitude,plane_vspeed

--- a/doc/telemetry-protocol-map.md
+++ b/doc/telemetry-protocol-map.md
@@ -1,0 +1,54 @@
+# Telemetry Protocol Map
+
+This document maps each `app_state_t` field to the protocols that provide it. The data type column reflects the native type supplied by the protocol parser.
+
+| Field | CRSF | MAVLINK | MSP | MSP_V2 | NMEA | UBLOX |
+|-------|------|---------|-----|--------|------|-------|
+| plane_longitude | int32_t | int32_t | int32_t | int32_t | int32_t | int32_t |
+| plane_latitude | int32_t | int32_t | int32_t | int32_t | int32_t | int32_t |
+| plane_altitude | int32_t | int32_t | int32_t | int32_t | int32_t | int32_t |
+| plane_baro_altitude | int16_t | int16_t | int16_t | - | - | - |
+| plane_fused_altitude | int32_t | - | - | - | - | - |
+| plane_speed | - | int16_t | int16_t | int16_t | int16_t | int16_t |
+| plane_distance | - | - | - | - | - | - |
+| plane_star | uint8_t | - | uint8_t | uint8_t | uint8_t | - |
+| plane_fix | uint8_t | - | uint8_t | uint8_t | uint8_t | - |
+| plane_pitch | int16_t | - | int16_t | int16_t | - | - |
+| plane_roll | int16_t | - | int16_t | int16_t | - | - |
+| plane_heading | int16_t | int16_t | int16_t | int16_t | int16_t | int16_t |
+| plane_vbat | uint16_t | - | uint16_t | uint16_t | - | - |
+| plane_battery | uint16_t | - | uint16_t | uint16_t | - | - |
+| plane_rssi | uint8_t | - | uint8_t | - | - | - |
+| plane_vspeed | int16_t | int16_t | int16_t | - | - | - |
+| plane_flight_mode | string | - | string | - | - | - |
+| plane_esc_rpm | int32_t | - | - | - | - | - |
+| plane_esc_voltage | uint16_t | - | - | - | - | - |
+| plane_esc_current | uint16_t | - | uint16_t | - | - | - |
+| plane_esc_temperature | uint8_t | - | - | - | - | - |
+| plane_vtx_band | uint8_t | - | - | - | - | - |
+| plane_vtx_channel | uint8_t | - | - | - | - | - |
+| plane_vtx_power | uint8_t | - | - | - | - | - |
+| plane_rc_channels | - | - | - | - | - | - |
+| plane_armed | - | - | uint8_t | - | - | - |
+| plane_home_dist | - | - | int16_t | - | - | - |
+| plane_home_dir | - | - | int16_t | - | - | - |
+| plane_gps_hdop | - | - | - | - | uint16_t | - |
+| plane_gps_vdop | - | - | - | - | uint16_t | - |
+| plane_gps_pdop | - | - | - | - | uint16_t | - |
+| plane_gps_fix_mode | - | - | - | - | uint8_t | - |
+| plane_gps_sats_in_view | - | - | - | - | uint8_t | - |
+| plane_gps_geo_sep | - | - | - | - | int16_t | - |
+| plane_gps_mag_variation | - | - | - | - | int16_t | - |
+| plane_uplink_rssi | int8_t | - | - | - | - | - |
+| plane_uplink_lq | uint8_t | - | - | - | - | - |
+| plane_uplink_snr | int8_t | - | - | - | - | - |
+| plane_downlink_rssi | int8_t | - | - | - | - | - |
+| plane_downlink_lq | uint8_t | - | - | - | - | - |
+| plane_downlink_snr | int8_t | - | - | - | - | - |
+| plane_rf_power_level | uint8_t | - | - | - | - | - |
+| plane_gps_time_hours | - | - | - | - | uint8_t | - |
+| plane_gps_time_minutes | - | - | - | - | uint8_t | - |
+| plane_gps_time_seconds | - | - | - | - | uint8_t | - |
+| plane_gps_date_day | - | - | - | - | uint8_t | - |
+| plane_gps_date_month | - | - | - | - | uint8_t | - |
+| plane_gps_date_year | - | - | - | - | uint8_t | - |

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -105,81 +105,80 @@ typedef struct app_state_s {
     app_err_t system_error_code;
     app_mode_t current_mode;  // Current application mode
     // Plane telemetry
-    int32_t plane_longitude;
-    int32_t plane_latitude;
-    int32_t plane_altitude;  // GPS altitude (m)
-    // TODO convert to int16_t
-    int32_t plane_baro_altitude;   // Baro altitude (m or dm->m converted)
-    int32_t plane_fused_altitude;  // NEW: fused altitude (m)
-    int16_t plane_speed;
-    uint32_t plane_distance;
-    uint8_t plane_star;
-    uint8_t plane_fix;
-    int16_t plane_pitch;
-    int16_t plane_roll;
-    int16_t plane_heading;
-    uint16_t plane_vbat;
-    uint16_t plane_battery;
-    uint8_t plane_rssi;
-    int16_t plane_vspeed;            // Vertical speed in m/s * 10
-    char plane_flight_mode[24];      // Flight mode string
-    int32_t plane_esc_rpm;           // ESC RPM
-    uint16_t plane_esc_voltage;      // ESC voltage in mV
-    uint16_t plane_esc_current;      // ESC current in mA
-    uint8_t plane_esc_temperature;   // ESC temperature in °C
-    uint8_t plane_vtx_band;          // VTX band
-    uint8_t plane_vtx_channel;       // VTX channel
-    uint8_t plane_vtx_power;         // VTX power level
-    uint16_t plane_rc_channels[18];  // RC channel values (11-bit each)
+    int32_t plane_longitude;         // Provided by: CRSF, MAVLINK, MSP, MSP_V2, NMEA, UBLOX
+    int32_t plane_latitude;          // Provided by: CRSF, MAVLINK, MSP, MSP_V2, NMEA, UBLOX
+    int32_t plane_altitude;          // GPS altitude (m) - Provided by: CRSF, MAVLINK, MSP, MSP_V2, NMEA, UBLOX
+    int16_t plane_baro_altitude;     // Baro altitude (m or dm->m converted) - Provided by: CRSF, MAVLINK, MSP
+    int32_t plane_fused_altitude;    // Fused altitude (m) - Provided by: CRSF
+    int16_t plane_speed;             // Provided by: MAVLINK, MSP, MSP_V2, NMEA, UBLOX
+    uint32_t plane_distance;         // Provided by: -
+    uint8_t plane_star;              // Provided by: CRSF, MSP, MSP_V2, NMEA
+    uint8_t plane_fix;               // Provided by: CRSF, MSP, MSP_V2, NMEA
+    int16_t plane_pitch;             // Provided by: CRSF, MSP, MSP_V2
+    int16_t plane_roll;              // Provided by: CRSF, MSP, MSP_V2
+    int16_t plane_heading;           // Provided by: CRSF, MAVLINK, MSP, MSP_V2, NMEA, UBLOX
+    uint16_t plane_vbat;             // Provided by: CRSF, MSP, MSP_V2
+    uint16_t plane_battery;          // Provided by: CRSF, MSP, MSP_V2
+    uint8_t plane_rssi;              // Provided by: CRSF, MSP
+    int16_t plane_vspeed;            // Vertical speed in m/s * 10 - Provided by: CRSF, MAVLINK, MSP
+    char plane_flight_mode[24];      // Flight mode string - Provided by: CRSF, MSP
+    int32_t plane_esc_rpm;           // ESC RPM - Provided by: CRSF
+    uint16_t plane_esc_voltage;      // ESC voltage in mV - Provided by: CRSF
+    uint16_t plane_esc_current;      // ESC current in mA - Provided by: CRSF, MSP
+    uint8_t plane_esc_temperature;   // ESC temperature in °C - Provided by: CRSF
+    uint8_t plane_vtx_band;          // VTX band - Provided by: CRSF
+    uint8_t plane_vtx_channel;       // VTX channel - Provided by: CRSF
+    uint8_t plane_vtx_power;         // VTX power level - Provided by: CRSF
+    uint16_t plane_rc_channels[18];  // RC channel values (11-bit each) - Provided by: -
 
     // Missing fields that are used by protocols
-    uint8_t plane_armed;      // Armed status (0/1)
-    int16_t plane_home_dist;  // Distance to home in meters
-    int16_t plane_home_dir;   // Direction to home in degrees
+    uint8_t plane_armed;              // Armed status (0/1) - Provided by: MSP
+    int16_t plane_home_dist;          // Distance to home in meters - Provided by: MSP
+    int16_t plane_home_dir;           // Direction to home in degrees - Provided by: MSP
 
     // Additional GPS parameters
-    uint16_t plane_gps_hdop;          // Horizontal dilution of precision * 100
-    uint16_t plane_gps_vdop;          // Vertical dilution of precision * 100
-    uint16_t plane_gps_pdop;          // Position dilution of precision * 100
-    uint8_t plane_gps_fix_mode;       // Fix mode (1=no fix, 2=2D, 3=3D)
-    uint8_t plane_gps_sats_in_view;   // Number of satellites in view
-    int16_t plane_gps_geo_sep;        // Geoid separation in cm
-    int16_t plane_gps_mag_variation;  // Magnetic variation in degrees * 10
+    uint16_t plane_gps_hdop;          // Horizontal dilution of precision * 100 - Provided by: NMEA
+    uint16_t plane_gps_vdop;          // Vertical dilution of precision * 100 - Provided by: NMEA
+    uint16_t plane_gps_pdop;          // Position dilution of precision * 100 - Provided by: NMEA
+    uint8_t plane_gps_fix_mode;       // Fix mode (1=no fix, 2=2D, 3=3D) - Provided by: NMEA
+    uint8_t plane_gps_sats_in_view;   // Number of satellites in view - Provided by: NMEA
+    int16_t plane_gps_geo_sep;        // Geoid separation in cm - Provided by: NMEA
+    int16_t plane_gps_mag_variation;  // Magnetic variation in degrees * 10 - Provided by: NMEA
 
     // Additional telemetry parameters
-    int8_t plane_uplink_rssi;      // Uplink RSSI in dBm
-    uint8_t plane_uplink_lq;       // Uplink link quality in %
-    int8_t plane_uplink_snr;       // Uplink SNR in dB
-    int8_t plane_downlink_rssi;    // Downlink RSSI in dBm
-    uint8_t plane_downlink_lq;     // Downlink link quality in %
-    int8_t plane_downlink_snr;     // Downlink SNR in dB
-    uint8_t plane_rf_power_level;  // RF power level
+    int8_t plane_uplink_rssi;      // Uplink RSSI in dBm - Provided by: CRSF
+    uint8_t plane_uplink_lq;       // Uplink link quality in % - Provided by: CRSF
+    int8_t plane_uplink_snr;       // Uplink SNR in dB - Provided by: CRSF
+    int8_t plane_downlink_rssi;    // Downlink RSSI in dBm - Provided by: CRSF
+    uint8_t plane_downlink_lq;     // Downlink link quality in % - Provided by: CRSF
+    int8_t plane_downlink_snr;     // Downlink SNR in dB - Provided by: CRSF
+    uint8_t plane_rf_power_level;  // RF power level - Provided by: CRSF
 
     // Additional ESC telemetry (for multiple ESCs)
-    int32_t plane_esc2_rpm;          // ESC2 RPM
-    uint16_t plane_esc2_voltage;     // ESC2 voltage in mV
-    uint16_t plane_esc2_current;     // ESC2 current in mA
-    uint8_t plane_esc2_temperature;  // ESC2 temperature in °C
-    int32_t plane_esc3_rpm;          // ESC3 RPM
-    uint16_t plane_esc3_voltage;     // ESC3 voltage in mV
-    uint16_t plane_esc3_current;     // ESC3 current in mA
-    uint8_t plane_esc3_temperature;  // ESC3 temperature in °C
-    int32_t plane_esc4_rpm;          // ESC4 RPM
-    uint16_t plane_esc4_voltage;     // ESC4 voltage in mV
-    uint16_t plane_esc4_current;     // ESC4 current in mA
-    uint8_t plane_esc4_temperature;  // ESC4 temperature in °C
+    int32_t plane_esc2_rpm;          // ESC2 RPM - Provided by: -
+    uint16_t plane_esc2_voltage;     // ESC2 voltage in mV - Provided by: -
+    uint16_t plane_esc2_current;     // ESC2 current in mA - Provided by: -
+    uint8_t plane_esc2_temperature;  // ESC2 temperature in °C - Provided by: -
+    int32_t plane_esc3_rpm;          // ESC3 RPM - Provided by: -
+    uint16_t plane_esc3_voltage;     // ESC3 voltage in mV - Provided by: -
+    uint16_t plane_esc3_current;     // ESC3 current in mA - Provided by: -
+    uint8_t plane_esc3_temperature;  // ESC3 temperature in °C - Provided by: -
+    int32_t plane_esc4_rpm;          // ESC4 RPM - Provided by: -
+    uint16_t plane_esc4_voltage;     // ESC4 voltage in mV - Provided by: -
+    uint16_t plane_esc4_current;     // ESC4 current in mA - Provided by: -
+    uint8_t plane_esc4_temperature;  // ESC4 temperature in °C - Provided by: -
 
     // Additional time/date parameters
-    uint8_t plane_gps_time_hours;    // GPS time hours
-    uint8_t plane_gps_time_minutes;  // GPS time minutes
-    uint8_t plane_gps_time_seconds;  // GPS time seconds
-    uint8_t plane_gps_date_day;      // GPS date day
-    uint8_t plane_gps_date_month;    // GPS date month
-    uint8_t plane_gps_date_year;     // GPS date year (2-digit)
-    uint8_t piezo_mask;              // Piezo comparator bitmask
-    int16_t accel_x;                 // Raw accelerometer data X
-    int16_t accel_y;                 // Raw accelerometer data Y
-    int16_t accel_z;                 // Raw accelerometer data Z
+    uint8_t plane_gps_time_hours;    // GPS time hours - Provided by: NMEA
+    uint8_t plane_gps_time_minutes;  // GPS time minutes - Provided by: NMEA
+    uint8_t plane_gps_time_seconds;  // GPS time seconds - Provided by: NMEA
+    uint8_t plane_gps_date_day;      // GPS date day - Provided by: NMEA
+    uint8_t plane_gps_date_month;    // GPS date month - Provided by: NMEA
+    uint8_t plane_gps_date_year;     // GPS date year (2-digit) - Provided by: NMEA
+    uint8_t piezo_mask;              // Piezo comparator bitmask - Provided by: -
+    int16_t accel_x;                 // Raw accelerometer data X - Provided by: -
+    int16_t accel_y;                 // Raw accelerometer data Y - Provided by: -
+    int16_t accel_z;                 // Raw accelerometer data Z - Provided by: -
 
     Notifier *changed_notifier;
     uint64_t changed_mask;

--- a/src/protocols/crsf.c
+++ b/src/protocols/crsf.c
@@ -333,7 +333,7 @@ bool crsf_process_frame(crsf_state_t *state, const uint8_t *frame_data, size_t f
 
             app_state_t *app_state = app_state_get_instance();
             app_state_begin_update();
-            app_state_set_i32(APP_STATE_FIELD_PLANE_BARO_ALTITUDE, &app_state->plane_baro_altitude, (int32_t)baro_alt_raw);
+            app_state_set_i16(APP_STATE_FIELD_PLANE_BARO_ALTITUDE, &app_state->plane_baro_altitude, (int16_t)baro_alt_raw);
             app_state_set_i32(APP_STATE_FIELD_PLANE_FUSED_ALTITUDE, &app_state->plane_fused_altitude, (int32_t)lroundf(fused));
             app_state_end_update();
 

--- a/src/protocols/mavlink.c
+++ b/src/protocols/mavlink.c
@@ -156,7 +156,7 @@ static bool mavlink_process_frame(mavlink_state_t *state, const uint8_t *frame_d
             app_state_set_i32(APP_STATE_FIELD_PLANE_LATITUDE, &app_state->plane_latitude, pos.lat);
             app_state_set_i32(APP_STATE_FIELD_PLANE_LONGITUDE, &app_state->plane_longitude, pos.lon);
             app_state_set_i32(APP_STATE_FIELD_PLANE_ALTITUDE, &app_state->plane_altitude, pos.alt / 1000);                     // в метри
-            app_state_set_i32(APP_STATE_FIELD_PLANE_BARO_ALTITUDE, &app_state->plane_baro_altitude, pos.relative_alt / 1000);  // в метри
+            app_state_set_i16(APP_STATE_FIELD_PLANE_BARO_ALTITUDE, &app_state->plane_baro_altitude, (int16_t)(pos.relative_alt / 1000));  // в метри
             app_state_set_i16(APP_STATE_FIELD_PLANE_SPEED, &app_state->plane_speed, (int16_t)(ground_speed_mps * 100));        // в см/с
             app_state_set_i16(APP_STATE_FIELD_PLANE_HEADING, &app_state->plane_heading, pos.hdg / 100);                        // в градуси
             app_state_end_update();

--- a/src/protocols/msp.c
+++ b/src/protocols/msp.c
@@ -309,7 +309,7 @@ static void msp_process_packet(msp_state_t *state, uint8_t cmd, const uint8_t *p
                 memcpy(&vario, payload + 4, sizeof(int16_t));
 
                 app_state_begin_update();
-                app_state_set_i32(APP_STATE_FIELD_PLANE_BARO_ALTITUDE, &app_state->plane_baro_altitude, alt / 100);
+                app_state_set_i16(APP_STATE_FIELD_PLANE_BARO_ALTITUDE, &app_state->plane_baro_altitude, (int16_t)(alt / 100));
                 app_state_set_i16(APP_STATE_FIELD_PLANE_VSPEED, &app_state->plane_vspeed, vario);
                 app_state_end_update();
                 LOG_D(TAG, "ALTITUDE: Alt=%.2fm Vario=%.2fm/s", (float)alt / 100.0f, (float)vario / 100.0f);


### PR DESCRIPTION
## Summary
- Map protocol data types for `app_state_t` fields and document them for developers and users
- Shrink `plane_baro_altitude` to `int16_t` and update protocol parsers accordingly
- Rework config docs to list telemetry fields per protocol with sizes

## Testing
- `pio test` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf67842a88320b2e66dd134be6ad1