### PR TITLE
Use HAL GPIO helpers in modules

### DIFF
--- a/src/modules/accel_module.c
+++ b/src/modules/accel_module.c
@@ -159,17 +159,9 @@ hal_err_t accel_module_init(accel_module_t *module, const accel_config_t *config
     }
     LOG_I(TAG, "LIS3DH INT1 pin configured for data-ready signal.");
 
-    // --- Configure ESP32 GPIO to receive the interrupt ---
-    hal_gpio_config_t io_conf;
-    io_conf.pin = ACC_INT_GPIO;
-    io_conf.mode = HAL_GPIO_MODE_INPUT;
-    io_conf.pull_up_en = false;
-    io_conf.pull_down_en = true;
-    io_conf.intr_type = HAL_GPIO_INTR_POSEDGE;
-    hal_gpio_config(&io_conf);
-
-    hal_gpio_install_isr_service(0);
-    hal_gpio_isr_handler_add(ACC_INT_GPIO, accel_isr_handler, (void *)module);
+    // --- Configure GPIO to receive the interrupt using HAL ---
+    hal_gpio_setup(ACC_INT_GPIO, HAL_GPIO_DIR_INPUT, HAL_GPIO_PULL_DOWN);
+    hal_gpio_set_isr(ACC_INT_GPIO, HAL_GPIO_INTR_POSEDGE, accel_isr_handler, (void *)module);
     LOG_I(TAG, "GPIO interrupt handler installed for ACC_INT_GPIO.");
 
     LOG_I(TAG, "LIS3DH initialized successfully.");

--- a/src/modules/pz_module.c
+++ b/src/modules/pz_module.c
@@ -21,10 +21,10 @@ static void IRAM_ATTR pz_gpio_isr_handler(void *arg) {
     uint8_t mask = 0;
 
     // Read the state of all 4 comparator pins
-    if (gpio_get_level(COMP_1_OUT_GPIO)) mask |= (1 << 0);
-    if (gpio_get_level(COMP_2_OUT_GPIO)) mask |= (1 << 1);
-    if (gpio_get_level(COMP_3_OUT_GPIO)) mask |= (1 << 2);
-    if (gpio_get_level(COMP_4_OUT_GPIO)) mask |= (1 << 3);
+    if (hal_gpio_get_level(COMP_1_OUT_GPIO)) mask |= (1 << 0);
+    if (hal_gpio_get_level(COMP_2_OUT_GPIO)) mask |= (1 << 1);
+    if (hal_gpio_get_level(COMP_3_OUT_GPIO)) mask |= (1 << 2);
+    if (hal_gpio_get_level(COMP_4_OUT_GPIO)) mask |= (1 << 3);
 
     // If any comparator triggered, send the mask to the queue
     if (mask > 0) {
@@ -53,8 +53,6 @@ app_err_t pz_module_init(pz_module_t *module) {
         LOG_E(TAG, "Failed to create event queue");
         return APP_ERR_GENERIC;
     }
-
-    gpio_install_isr_service(0);
 
     // 2. Initialize DAC channels
     dac_oneshot_config_t dac1_cfg = {


### PR DESCRIPTION
## Summary
- remove direct gpio ISR service installation in piezo module
- read comparator outputs via `hal_gpio_get_level`
- configure accelerometer interrupt pin using HAL helpers instead of ESP-IDF structs

## Testing
- `pio run -e lolin_s2_mini` *(fails: HTTPClientError while installing platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0f14d5548320bb56f20810f2423b