### PR TITLE
Check app mode before logging and skip fsync loop

### DIFF
--- a/src/modules/logger_module.c
+++ b/src/modules/logger_module.c
@@ -67,6 +67,10 @@ static void write_csv_line(logger_module_t *module) {
 
     app_state_t *state = app_state_get_instance();
 
+    if (state->current_mode != APP_MODE_LOGGING) {
+        return;
+    }
+
     char line[512];
     int offset = 0;
 
@@ -139,7 +143,6 @@ static void logger_task(void *arg) {
                 if (written != (int)chunk.size) {
                     LOG_E(TAG, "Failed to write log data (%d/%d)", written, (int)chunk.size);
                 }
-                sdcard_fsync(module->log_file);
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid unnecessary `sdcard_fsync` in `logger_task`
- only write CSV lines when application is in logging mode

## Testing
- `~/.local/bin/pio run -e lolin_s2_mini` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1f5c24b88320b548b13c0f6aff7b