### PR TITLE
Decouple logger with snapshot queue

### DIFF
--- a/src/app_logic.c
+++ b/src/app_logic.c
@@ -287,17 +287,17 @@ esp_err_t app_logic_start_all_tasks(app_logic_t *app) {
         LOG_W(TAG, "Skipping accel_module_task creation, module not initialized.");
     }
 
-    if (app->logger_module->initialized && app->logger_module->sd_card_ok && app->accel_module->initialized) {
+    if (app->logger_module->initialized && app->logger_module->sd_card_ok) {
         logger_module_create_task(app->logger_module);
-        app->logger_task_handle = app->logger_module->task_handle;
+        app->logger_task_handle = app->logger_module->writer_task_handle;
         if (app->logger_task_handle == NULL) {
-            LOG_E(TAG, "Failed to create logger_task");
+            LOG_E(TAG, "Failed to create logger tasks");
             result = ESP_FAIL;
         } else {
-            LOG_I(TAG, "logger_task created successfully");
+            LOG_I(TAG, "Logger tasks created successfully");
         }
     } else {
-        LOG_W(TAG, "Skipping logger_task creation, module not initialized.");
+        LOG_W(TAG, "Skipping logger task creation, module not initialized or SD card issue.");
     }
 
     if (app->pz_module->is_initialized) {

--- a/src/modules/logger_module.h
+++ b/src/modules/logger_module.h
@@ -30,14 +30,31 @@ typedef struct {
     size_t size;
 } logger_chunk_t;
 
+typedef union {
+    int16_t val_i16;
+    int32_t val_i32;
+    float val_f;
+} log_snapshot_value_u;
+
+typedef struct {
+    uint64_t timestamp_ms;
+    int16_t accel_x;
+    int16_t accel_y;
+    int16_t accel_z;
+    uint8_t piezo_mask;
+    log_snapshot_value_u telemetry_values[MAX_LOG_TELEMETRY_PARAMS];
+} log_data_snapshot_t;
+
 typedef struct logger_module_s {
     uint8_t ping_buffer[LOGGER_BUFFER_SIZE];
     uint8_t pong_buffer[LOGGER_BUFFER_SIZE];
     uint8_t *active_buffer;
     volatile size_t active_buffer_idx;
 
+    QueueHandle_t data_queue;
     QueueHandle_t buffer_queue;
-    TaskHandle_t task_handle;
+    TaskHandle_t processing_task_handle;
+    TaskHandle_t writer_task_handle;
     Observer *observer;
     sdcard_file_handle_t log_file;
     char csv_header[512];


### PR DESCRIPTION
## Summary
- introduce data snapshot structure and queue to decouple logger from app_state mutex
- add processing task to format CSV lines and a dedicated writer task for SD operations
- update application logic to start both logger tasks and track writer handle

## Testing
- `pio run -e lolin_s2_mini` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53e9efa083208d10c14b3476207b